### PR TITLE
Pin CommonMark version to keep stable API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-CommonMark
+CommonMark==0.5.4
 pandocfilters
 PyYAML
 pep8


### PR DESCRIPTION
Version 0.6.4 changes in a way that [breaks our tests](https://travis-ci.org/lhcb/second-analysis-steps/builds/130828884#L432).
